### PR TITLE
fixed requête in getCelliers()

### DIFF
--- a/modeles/Cellier.class.php
+++ b/modeles/Cellier.class.php
@@ -19,7 +19,7 @@ class Cellier extends Modele {
     }
     
 	public function getCelliers($userId){
-        $celliers = $this->_db->query("SELECT vc.id, vc.nom, COUNT(vcc.id) AS nbDeVins FROM vino__cellier vc LEFT JOIN vino__cellier_contient vcc ON vc.id = vcc.vino__cellier_id WHERE vc.vino__utilisateur_id = " .$userId. " GROUP BY vc.nom");
+        $celliers = $this->_db->query("SELECT vc.id, vc.nom, COUNT(vcc.id) AS nbDeVins FROM vino__cellier vc LEFT JOIN vino__cellier_contient vcc ON vc.id = vcc.vino__cellier_id WHERE vc.vino__utilisateur_id = " .$userId. " GROUP BY vc.nom, vc.id");
         $arrayCelliers = [];
         while($row = $celliers->fetch_assoc()){
             array_push($arrayCelliers, $row);


### PR DESCRIPTION
Il manque le champ vc.id dans le GROUP BY. Cette requête est à la ligne 22 de Cellier.class.php.